### PR TITLE
Add Convention Center Department sites to allowed origins

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -10,7 +10,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     if Rails.env.development?
       origins 'http://localhost:3001'
     elsif Rails.env.production?
-      origins 'austintexas.gov', 'http://alpha.austin.gov', 'https://coa-test-form-client.herokuapp.com', 'http://localhost:3000', 'http://localhost:8080'
+      origins 'austintexas.gov', 'http://alpha.austin.gov', 'https://coa-test-form-client.herokuapp.com', '*.palmereventscenter.com', '*.austinconventioncenter.com'
     end
     resource '*',
       headers: :any,


### PR DESCRIPTION
The original Formspree implementation for the RFP submission on the Convention Center sites has been behaving inconsistently over the last week so we are moving to the Form dispatcher for delivering form contents to the sales department's email distribution list.

This also fixes #1 . I thought about adding the ACC domains to the origin list for the development environment but decided it's probably easier just to manually put that in if/when I need to do my own testing rather than make that an infinitely growing list of localhost ports.